### PR TITLE
Handle relative backend URL in Astro auth middleware

### DIFF
--- a/template-baru/src/assets/js/auth.js
+++ b/template-baru/src/assets/js/auth.js
@@ -115,7 +115,7 @@ document.addEventListener('DOMContentLoaded', function () {
           }),
           success: function (result) {
             // simpan token ke cookie (expires 1 hari)
-            // document.cookie = `auth_token=${result.access_token}; path=/; max-age=86400; SameSite=Lax`;
+            // Cookie HttpOnly sudah dibuat oleh backend FastAPI melalui set_jwt_cookie
             localStorage.setItem('access_token', result.access_token);
             // ambil redirect dari query param
             const params = new URLSearchParams(window.location.search);

--- a/template-baru/src/env.d.ts
+++ b/template-baru/src/env.d.ts
@@ -1,5 +1,6 @@
 interface ImportMetaEnv {
     readonly BACKEND: string;
+    readonly PUBLIC_BACKEND_PATH: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- ensure the auth middleware builds an absolute verify URL so relative PUBLIC_BACKEND_PATH values work in Node
- document the PUBLIC_BACKEND_PATH environment variable for TypeScript consumers
- rely on the FastAPI HttpOnly cookie instead of writing the token from the browser script

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e359a182bc83338af3ad703dd94deb